### PR TITLE
Feat/config interceptor

### DIFF
--- a/src/api/AxiosClient.ts
+++ b/src/api/AxiosClient.ts
@@ -33,6 +33,11 @@ axiosClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+/**
+ * - access_token을 갱신하는 함수
+ * - 함수 아래 interceptors만 의존해야 하기 때문에 export하지 않음
+ * - API 명세의 요구에 맞춰 header를 활용하고 refresh token을 설정
+ */
 async function refreshAccessAPI() {
   try {
     const sessionToken = sessionStorage.getItem('sessionToken');

--- a/src/api/AxiosClient.ts
+++ b/src/api/AxiosClient.ts
@@ -1,6 +1,7 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import type { AxiosInstance } from 'axios';
 import { API_URLS, BASE_URL } from '../constant/config';
+import { refreshAccessAPI } from './authClient';
 
 const axiosClient: AxiosInstance = axios.create({
   baseURL: BASE_URL,
@@ -33,42 +34,6 @@ axiosClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
-/**
- * - access_token을 갱신하는 함수
- * - 함수 아래 interceptors만 의존해야 하기 때문에 export하지 않음
- * - API 명세의 요구에 맞춰 header를 활용하고 refresh token을 설정
- */
-async function refreshAccessAPI() {
-  try {
-    const sessionToken = sessionStorage.getItem('sessionToken');
-    if (!sessionToken) throw Error('sessionToken');
-
-    const {
-      data: { access_token },
-    } = await authClient.post<{
-      success: boolean;
-      access_token: string;
-    }>(API_URLS.REFRESH, null, {
-      headers: {
-        Authorization: `Bearer ${sessionToken.slice(
-          1,
-          sessionToken.length - 1
-        )}`,
-      },
-    });
-
-    localStorage.setItem('accessToken', `"${access_token}"`);
-
-    return access_token;
-  } catch (error) {
-    localStorage.clear();
-    sessionStorage.clear();
-    if (error instanceof AxiosError) {
-      return error.response?.data;
-    }
-  }
-}
-
 axiosClient.interceptors.response.use(
   (res) => res,
   async (err) => {
@@ -76,6 +41,7 @@ axiosClient.interceptors.response.use(
       config,
       response: { status },
     } = err;
+
     if (config.url === API_URLS.REFRESH || status !== 401 || config.sent) {
       return Promise.reject(err);
     }
@@ -85,6 +51,7 @@ axiosClient.interceptors.response.use(
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
     }
+
     return axiosClient(config);
   }
 );

--- a/src/api/AxiosClient.ts
+++ b/src/api/AxiosClient.ts
@@ -34,6 +34,7 @@ axiosClient.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+/** @see https://gusrb3164.github.io/web/2022/08/07/refresh-with-axios-for-client/ */
 axiosClient.interceptors.response.use(
   (res) => res,
   async (err) => {

--- a/src/api/authClient.ts
+++ b/src/api/authClient.ts
@@ -36,4 +36,39 @@ async function signUpAPI(email: string, password: string) {
   }
 }
 
-export { signInAPI, signUpAPI };
+/**
+ * - access_token을 갱신하는 함수
+ * - API 명세의 요구에 맞춰 authClient 중 유일하게 header를 활용하고 refresh token으로 설정
+ */
+async function refreshAccessAPI() {
+  try {
+    const sessionToken = sessionStorage.getItem('sessionToken');
+    if (!sessionToken) throw Error('sessionToken');
+
+    const {
+      data: { access_token },
+    } = await authClient.post<{
+      success: boolean;
+      access_token: string;
+    }>(API_URLS.REFRESH, null, {
+      headers: {
+        Authorization: `Bearer ${sessionToken.slice(
+          1,
+          sessionToken.length - 1
+        )}`,
+      },
+    });
+
+    localStorage.setItem('accessToken', `"${access_token}"`);
+
+    return access_token;
+  } catch (error) {
+    localStorage.clear();
+    sessionStorage.clear();
+    if (error instanceof AxiosError) {
+      return error.response?.data;
+    }
+  }
+}
+
+export { signInAPI, signUpAPI, refreshAccessAPI };

--- a/src/api/authClient.ts
+++ b/src/api/authClient.ts
@@ -39,6 +39,7 @@ async function signUpAPI(email: string, password: string) {
 /**
  * - access_token을 갱신하는 함수
  * - API 명세의 요구에 맞춰 authClient 중 유일하게 header를 활용하고 refresh token으로 설정
+ * - Jotai Storage로 set할 때는 큰따옴표(`"`)로 감싸기 때문에 slice가 필요함
  */
 async function refreshAccessAPI() {
   try {

--- a/src/api/authClient.ts
+++ b/src/api/authClient.ts
@@ -39,7 +39,7 @@ async function signUpAPI(email: string, password: string) {
 /**
  * - access_token을 갱신하는 함수
  * - API 명세의 요구에 맞춰 authClient 중 유일하게 header를 활용하고 refresh token으로 설정
- * - Jotai Storage로 set할 때는 큰따옴표(`"`)로 감싸기 때문에 slice가 필요함
+ * - Jotai Storage로 set하고 난 후에는 큰따옴표(`"`)로 감싸져있기 때문에 slice가 필요
  */
 async function refreshAccessAPI() {
   try {

--- a/src/constant/config.ts
+++ b/src/constant/config.ts
@@ -4,7 +4,7 @@ export const API_URLS = {
   CARDS: '/card',
   SIGN_IN: '/auth/signin',
   SIGN_UP: '/auth/signup',
-  SIGN_OUT: '/auth/signout',
+  REFRESH: '/auth/refresh',
 } as const;
 
 export const ROUTE_PATHS = {


### PR DESCRIPTION
## What is this PR? :mag:

- access token이 만료되었을 때 갱신하는 interceptor
- access token이 만료되었으면 session storage에서 refresh token을 접근 authClient header로 설정하고 갱신 요청을 보냄
- 성공하면 응답을 access token으로 받고 웹 스토리지를 갱신
- 실패할 경우 로그아웃으로 취급하기 위해 웹 스토리지를 비움

## branch

- feat/config-interceptor -> dev

## Changes :memo:

- 상수 문자열 중 sign out을 삭제하고 refresh를 추가함

(#9 ) by @arch-spatula
