### PR TITLE
chore: init vite alias #6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,13 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,21 @@
 /// <reference types="vitest" />
 /// <reference types="vite/client" />
 
-import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     globals: true,
-    environment: "jsdom",
-    setupFiles: ["./src/setup.ts"],
+    environment: 'jsdom',
+    setupFiles: ['./src/setup.ts'],
   },
 });


### PR DESCRIPTION
## What is this PR? :mag:

- Vite 개발환경에 적절한 alias 설정
- 참고. CRA는 craco를 활용해야 함
  - 하지만 vite은 craco를 이용할 필요 없음

## branch

- refactor/alias -> dev

## Changes :memo:

- tsconfig.json은 자동완성을 위해 필요하고 vite.config은 실제 번들링 처리할 때 필요함

(#6 ) by @arch-spatula
