### PR TITLE
Feat/card optimistic update create

### DIFF
--- a/src/Components/Common/Card/Card.tsx
+++ b/src/Components/Common/Card/Card.tsx
@@ -2,7 +2,7 @@ import { CardWrapper } from './Card.style';
 import { Provider } from 'jotai';
 import { CardBack, CardFront, EditCard } from './subcomponents';
 
-export function Card({ question, answer, _id, stackCount }: Card) {
+export function Card({ question, answer, _id, stackCount, submitDate }: Card) {
   return (
     <Provider>
       <CardWrapper>
@@ -13,6 +13,7 @@ export function Card({ question, answer, _id, stackCount }: Card) {
               question={question}
               answer={answer}
               stackCount={stackCount}
+              submitDate={submitDate}
             />
             <CardFront _id={_id} question={question} answer={answer} />
             <CardBack

--- a/src/Components/Common/Card/subcomponents/CardBack/CardBack.tsx
+++ b/src/Components/Common/Card/subcomponents/CardBack/CardBack.tsx
@@ -1,6 +1,9 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useAtomInput, useCardSide, useCorrect } from '../../../../../hooks';
-import { updateCardsAPI } from '../../../../../api/cardClient';
+import {
+  useAtomInput,
+  useCardMutation,
+  useCardSide,
+  useCorrect,
+} from '@/hooks';
 import {
   AnswerContainer,
   CardBackContainer,
@@ -17,34 +20,8 @@ type CardBackProps = {
 };
 
 export function CardBack({ _id, answer, question, stackCount }: CardBackProps) {
-  const queryClient = useQueryClient();
-  const { mutate: updateCard } = useMutation({
-    mutationFn: updateCardsAPI,
-    onMutate: async (cardItem) => {
-      await queryClient.cancelQueries({ queryKey: ['cards'] });
-
-      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
-
-      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
-        if (oldCards) {
-          return [...oldCards].map((card) =>
-            card._id === cardItem.id
-              ? { _id: cardItem.id, ...cardItem.card }
-              : card
-          );
-        } else return [];
-      });
-      return { previousCards };
-    },
-    onError: (_err, _cardItem, context) => {
-      if (context) queryClient.setQueryData(['cards'], context.previousCards);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['cards'] });
-    },
-  });
-
   const { cardSide, toggleTo } = useCardSide();
+  const { updateCard } = useCardMutation();
 
   const { isCorrect } = useCorrect();
   const { inputVal, resetInputVal } = useAtomInput();

--- a/src/Components/Common/Card/subcomponents/CardSetting/index.tsx
+++ b/src/Components/Common/Card/subcomponents/CardSetting/index.tsx
@@ -1,34 +1,11 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCardSide } from '../../../../../hooks';
 import { useCallback } from 'react';
 import { DropdownMenu } from '../../..';
 import { MenuWrapper } from './CardSetting.style';
-import { deleteCardsAPI } from '../../../../../api/cardClient';
+import { useCardMutation, useCardSide } from '@/hooks';
 
 export function CardSetting({ _id }: { _id: string }) {
   const { toggleTo } = useCardSide();
-  const queryClient = useQueryClient();
-  const { mutate: deleteCard } = useMutation({
-    mutationFn: deleteCardsAPI,
-    onMutate: async (cardId) => {
-      await queryClient.cancelQueries({ queryKey: ['cards'] });
-
-      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
-
-      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
-        if (oldCards)
-          return [...oldCards].filter((card) => card._id !== cardId);
-        else [];
-      });
-      return { previousCards };
-    },
-    onError: (_err, _cardId, context) => {
-      if (context) queryClient.setQueryData(['cards'], context.previousCards);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['cards'] });
-    },
-  });
+  const { deleteCard } = useCardMutation();
 
   const handleDelete = useCallback(() => {
     if (_id) deleteCard(_id);

--- a/src/Components/Common/Card/subcomponents/CardSetting/index.tsx
+++ b/src/Components/Common/Card/subcomponents/CardSetting/index.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCardSide } from '../../../../../hooks';
 import { useCallback } from 'react';
 import { DropdownMenu } from '../../..';
@@ -7,7 +7,28 @@ import { deleteCardsAPI } from '../../../../../api/cardClient';
 
 export function CardSetting({ _id }: { _id: string }) {
   const { toggleTo } = useCardSide();
-  const { mutate: deleteCard } = useMutation({ mutationFn: deleteCardsAPI });
+  const queryClient = useQueryClient();
+  const { mutate: deleteCard } = useMutation({
+    mutationFn: deleteCardsAPI,
+    onMutate: async (cardId) => {
+      await queryClient.cancelQueries({ queryKey: ['cards'] });
+
+      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
+
+      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
+        if (oldCards)
+          return [...oldCards].filter((card) => card._id !== cardId);
+        else [];
+      });
+      return { previousCards };
+    },
+    onError: (_err, _cardId, context) => {
+      if (context) queryClient.setQueryData(['cards'], context.previousCards);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['cards'] });
+    },
+  });
 
   const handleDelete = useCallback(() => {
     if (_id) deleteCard(_id);

--- a/src/Components/Common/Card/subcomponents/EditCard/EditCard.tsx
+++ b/src/Components/Common/Card/subcomponents/EditCard/EditCard.tsx
@@ -24,13 +24,13 @@ export function EditCard({
       const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
 
       queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
-        if (oldCards) {
+        if (oldCards)
           return [...oldCards].map((card) =>
             card._id === cardItem.id
               ? { _id: cardItem.id, ...cardItem.card }
               : card
           );
-        } else return [];
+        else return [];
       });
       return { previousCards };
     },

--- a/src/Components/Common/Card/subcomponents/EditCard/EditCard.tsx
+++ b/src/Components/Common/Card/subcomponents/EditCard/EditCard.tsx
@@ -1,6 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCardSide, useInput } from '../../../../../hooks';
-import { updateCardsAPI } from '../../../../../api/cardClient';
+import { useCardMutation, useCardSide, useInput } from '@/hooks';
 import { Button, Input } from '../../..';
 import { CardEditContainer } from './EditCard.style';
 
@@ -15,32 +13,7 @@ export function EditCard({
 }: EditCardProps) {
   const { cardSide, togglePrev } = useCardSide();
 
-  const queryClient = useQueryClient();
-  const { mutate: updateCard } = useMutation({
-    mutationFn: updateCardsAPI,
-    onMutate: async (cardItem) => {
-      await queryClient.cancelQueries({ queryKey: ['cards'] });
-
-      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
-
-      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
-        if (oldCards)
-          return [...oldCards].map((card) =>
-            card._id === cardItem.id
-              ? { _id: cardItem.id, ...cardItem.card }
-              : card
-          );
-        else return [];
-      });
-      return { previousCards };
-    },
-    onError: (_err, _cardItem, context) => {
-      if (context) queryClient.setQueryData(['cards'], context.previousCards);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['cards'] });
-    },
-  });
+  const { updateCard } = useCardMutation();
 
   const {
     inputVal: questionVal,

--- a/src/api/cardClient.ts
+++ b/src/api/cardClient.ts
@@ -11,6 +11,7 @@ async function getCardsAPI() {
       return error.message;
     }
   }
+  return [];
 }
 
 async function createCardsAPI(card: Card) {

--- a/src/api/cardClient.ts
+++ b/src/api/cardClient.ts
@@ -16,8 +16,11 @@ async function getCardsAPI() {
 
 async function createCardsAPI(card: Card) {
   try {
-    const res = await axiosClient.post(API_URLS.CARDS, card);
-    return res;
+    const res = await axiosClient.post<{ insertedId: string }>(
+      API_URLS.CARDS,
+      card
+    );
+    return res.data.insertedId;
   } catch (error) {
     if (error instanceof AxiosError) {
       return error;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useCards';
 export * from './useCardSide';
 export * from './useAtomInput';
 export * from './useCorrect';
+export * from './useCardMutation';

--- a/src/hooks/useCardMutation/index.ts
+++ b/src/hooks/useCardMutation/index.ts
@@ -1,0 +1,56 @@
+import { deleteCardsAPI, updateCardsAPI } from '@/api/cardClient';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useCardMutation() {
+  const queryClient = useQueryClient();
+
+  const { mutate: updateCard } = useMutation({
+    mutationFn: updateCardsAPI,
+    onMutate: async (cardItem) => {
+      await queryClient.cancelQueries({ queryKey: ['cards'] });
+
+      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
+
+      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
+        if (oldCards) {
+          return [...oldCards].map((card) =>
+            card._id === cardItem.id
+              ? { _id: cardItem.id, ...cardItem.card }
+              : card
+          );
+        } else return [];
+      });
+      return { previousCards };
+    },
+    onError: (_err, _cardItem, context) => {
+      if (context) queryClient.setQueryData(['cards'], context.previousCards);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['cards'] });
+    },
+  });
+
+  const { mutate: deleteCard } = useMutation({
+    mutationFn: deleteCardsAPI,
+    onMutate: async (cardId) => {
+      await queryClient.cancelQueries({ queryKey: ['cards'] });
+
+      const previousCards: Card[] = queryClient.getQueryData(['cards']) ?? [];
+
+      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
+        if (oldCards)
+          return [...oldCards].filter((card) => card._id !== cardId);
+        else [];
+      });
+      return { previousCards };
+    },
+    onError: (_err, _cardId, context) => {
+      if (context) queryClient.setQueryData(['cards'], context.previousCards);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['cards'] });
+    },
+  });
+
+  return { deleteCard, updateCard };
+}

--- a/src/hooks/useCardMutation/index.ts
+++ b/src/hooks/useCardMutation/index.ts
@@ -1,4 +1,8 @@
-import { deleteCardsAPI, updateCardsAPI } from '@/api/cardClient';
+import {
+  createCardsAPI,
+  deleteCardsAPI,
+  updateCardsAPI,
+} from '@/api/cardClient';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export function useCardMutation() {
@@ -52,5 +56,21 @@ export function useCardMutation() {
     },
   });
 
-  return { deleteCard, updateCard };
+  const { mutate: createCard, isLoading: isCreateCardLoading } = useMutation({
+    mutationFn: createCardsAPI,
+
+    onSuccess: (newCardId, newCard) => {
+      queryClient.setQueryData<Card[]>(['cards'], (oldCards) => {
+        if (oldCards && typeof newCardId === 'string')
+          return [...oldCards, { ...newCard, _id: newCardId }];
+        else return [];
+      });
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['cards'] });
+    },
+  });
+
+  return { deleteCard, updateCard, createCard, isCreateCardLoading };
 }

--- a/src/pages/Cards/index.tsx
+++ b/src/pages/Cards/index.tsx
@@ -21,7 +21,7 @@ function Cards() {
       {isLoading ? (
         <LoaderContainer>
           <PulseLoader
-            color={theme.colors.green}
+            color={theme.colors.green500}
             loading
             margin={4}
             size={20}

--- a/src/pages/Deck/index.tsx
+++ b/src/pages/Deck/index.tsx
@@ -1,8 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
 import { Button, Card, Input, PageHeading } from '../../Components';
-import { useCards, useInput } from '../../hooks';
+import { useCardMutation, useCards, useInput } from '@/hooks';
 import { AddCardContainer } from './Deck.style';
-import { createCardsAPI } from '../../api/cardClient';
 
 function Deck() {
   const { cards, error } = useCards();
@@ -17,7 +15,7 @@ function Deck() {
     resetInputVal: resetAnswer,
   } = useInput();
 
-  const { mutate } = useMutation({ mutationFn: createCardsAPI });
+  const { createCard, isCreateCardLoading } = useCardMutation();
 
   const disabled = [question, answer].some((elem) => !elem);
 
@@ -27,7 +25,7 @@ function Deck() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    mutate(
+    createCard(
       {
         question,
         answer,
@@ -35,8 +33,7 @@ function Deck() {
         stackCount: 0,
       },
       {
-        onSuccess: (data) => {
-          console.log(data);
+        onSuccess: () => {
           resetQuestion();
           resetAnswer();
         },
@@ -55,7 +52,9 @@ function Deck() {
         <Input value={question} onChange={changeQuestion} placeholder="설정" />
         <h3>정답</h3>
         <Input value={answer} onChange={changeAnswer} placeholder="configure" />
-        <Button disabled={disabled}>카드 생성</Button>
+        <Button disabled={disabled} isLoading={isCreateCardLoading}>
+          카드 생성
+        </Button>
       </AddCardContainer>
 
       <>


### PR DESCRIPTION
## What is this PR? :mag:

- 카드 생성은 pessimistic update로 처리
  - 클라이언트 사이드에서 id를 생성할 수 없고 리액트 key 갱신은 불필요한 랜더링과 동작이 발생하기 때문 

## branch

- feat/card-optimistic-update-create -> dev

## Changes :memo:

- createCardsAPI는 string을 반환하도록 설정함

(#66 ) by @arch-spatula
